### PR TITLE
fix: implement ddp_all_reduce for distributed cost reduction

### DIFF
--- a/test_ddp.py
+++ b/test_ddp.py
@@ -78,6 +78,27 @@ class TestDDP(unittest.TestCase):
         config = call_args[0][0]
         self.assertEqual(config.nproc_per_node, 4)  # max(1, 8 // 2)
 
+    @patch('ddp.get_backend')
+    @patch('ddp.all_reduce')
+    def test_ddp_all_reduce_nccl(self, mock_all_reduce, mock_get_backend):
+        mock_get_backend.return_value = 'nccl'
+        tensor = torch.tensor([1.0, 2.0, 3.0])
+
+        ddp.ddp_all_reduce(tensor)
+
+        self.assertTrue(mock_all_reduce.called)
+
+    @patch('ddp.get_backend')
+    @patch('ddp.all_reduce')
+    def test_ddp_all_reduce_gloo(self, mock_all_reduce, mock_get_backend):
+        mock_get_backend.return_value = 'gloo'
+        tensor = torch.tensor([1.0, 2.0, 3.0])
+
+        with patch.dict(os.environ, {"WORLD_SIZE": "2"}):
+            ddp.ddp_all_reduce(tensor)
+
+        self.assertTrue(mock_all_reduce.called)
+
     @patch('builtins.open', new_callable=unittest.mock.mock_open, read_data='{"version": 1}')
     @patch('logging.config.dictConfig')
     def test_reconfig_logging(self, mock_dict_config, mock_open):


### PR DESCRIPTION
```
2026-02-08T11:11:29 - ddp - Process-1 - INFO - Launching single node DDP run gpt-example with 2 processes on device cpu
2026-02-08T11:11:32 - neural_net_model - SpawnProcess-1:2 - INFO - DDP local rank 1 - training model gpt-example on device cpu with backend gloo
2026-02-08T11:11:32 - neural_net_model - SpawnProcess-1:1 - INFO - DDP local rank 0 - training model gpt-example on device cpu with backend gloo
2026-02-08T11:11:32 - neural_net_model - SpawnProcess-1:1 - INFO - Retrieving model from /dev/shm/models/model_gpt-example.pth...
2026-02-08T11:11:33 - neural_net_model - SpawnProcess-1:1 - INFO - Loaded model gpt-example data
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Created model gpt-example
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Loaded state into model gpt-example
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Loaded optimizer for model gpt-example
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example is fully loaded
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Moved model gpt-example to device cpu
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Training model using device cpu
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Training starts from idx 0 of ds tiny-shakespeare at shard 1 offset every 4096
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Training batch size: 2, buffer size: 2048, step size: 2
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Training calc to be done in 1 step(s) repeated 4 epoch(s)
2026-02-08T11:11:36 - loaders - SpawnProcess-1:1 - INFO - Found 4 shard(s) for tiny-shakespeare
2026-02-08T11:11:36 - neural_net_model - SpawnProcess-1:1 - INFO - Caching model to /dev/shm/models/model_gpt-example.pth...
2026-02-08T11:11:37 - neural_net_model - SpawnProcess-1:2 - INFO - Training starts from idx 2048 of ds tiny-shakespeare at shard 1 offset every 4096
2026-02-08T11:11:37 - neural_net_model - SpawnProcess-1:1 - INFO - Model cached successfully: /dev/shm/models/model_gpt-example.pth
2026-02-08T11:11:37 - neural_net_model - SpawnProcess-1:1 - INFO - Offload flushing model cache /dev/shm/models/model_gpt-example.pth to models/model_gpt-example.pth...
2026-02-08T11:12:16 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example: Training Epoch 1, Cost: 10.9951, Duration: 36.94 secs, Speed: 55.44 tokens/sec
2026-02-08T11:12:56 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example: Training Epoch 2, Cost: 9.6159, Duration: 40.13 secs, Speed: 51.03 tokens/sec
2026-02-08T11:13:09 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example - Cost: 10.3055 Overall Cost: 10.3055
2026-02-08T11:13:09 - neural_net_model - SpawnProcess-1:1 - INFO - Caching model to /dev/shm/models/model_gpt-example.pth...
2026-02-08T11:13:12 - neural_net_model - SpawnProcess-1:1 - INFO - Model cached successfully: /dev/shm/models/model_gpt-example.pth
2026-02-08T11:13:12 - neural_net_model - SpawnProcess-1:1 - INFO - Offload flushing model cache /dev/shm/models/model_gpt-example.pth to models/model_gpt-example.pth...
2026-02-08T11:13:47 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example: Training Epoch 3, Cost: 9.0613, Duration: 34.39 secs, Speed: 59.55 tokens/sec
2026-02-08T11:14:29 - neural_net_model - SpawnProcess-1:2 - INFO - Process 1 - cleaning up
2026-02-08T11:14:30 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example: Training Epoch 4, Cost: 9.1214, Duration: 41.80 secs, Speed: 48.99 tokens/sec
2026-02-08T11:14:35 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example - Cost: 9.6984 Overall Cost: 10.0020
2026-02-08T11:14:35 - neural_net_model - SpawnProcess-1:1 - INFO - Caching model to /dev/shm/models/model_gpt-example.pth...
2026-02-08T11:14:37 - neural_net_model - SpawnProcess-1:1 - INFO - Model cached successfully: /dev/shm/models/model_gpt-example.pth
2026-02-08T11:14:37 - neural_net_model - SpawnProcess-1:1 - INFO - Offload flushing model cache /dev/shm/models/model_gpt-example.pth to models/model_gpt-example.pth...
2026-02-08T11:14:37 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example: Done training for 4 epochs.
2026-02-08T11:14:43 - neural_net_model - SpawnProcess-1:1 - INFO - Model gpt-example - Cost: 9.6984 Overall Cost: 9.8502
2026-02-08T11:14:43 - neural_net_model - SpawnProcess-1:1 - INFO - Caching model to /dev/shm/models/model_gpt-example.pth...
2026-02-08T11:14:45 - neural_net_model - SpawnProcess-1:1 - INFO - Model cached successfully: /dev/shm/models/model_gpt-example.pth
2026-02-08T11:14:45 - neural_net_model - SpawnProcess-1:1 - INFO - Offload flushing model cache /dev/shm/models/model_gpt-example.pth to models/model_gpt-example.pth...
2026-02-08T11:14:45 - neural_net_model - SpawnProcess-1:1 - INFO - Process 0 - cleaning up
2026-02-08T11:14:55 - main - MainProcess - INFO - Distributed training process completed for model gpt-example
```